### PR TITLE
Allow trailing comments in config.ini parsing

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -28,7 +28,6 @@ import os
 config_ini_path = os.environ.get('BRAKER4_CONFIG', 'config.ini')
 # Allow trailing # / ; comments on value lines (ConfigParser default is None).
 config_parser = configparser.ConfigParser(inline_comment_prefixes=('#', ';'))
-config_parser = configparser.ConfigParser()
 if not os.path.isfile(config_ini_path):
     raise FileNotFoundError(
         f"config.ini not found at '{config_ini_path}'. "

--- a/Snakefile
+++ b/Snakefile
@@ -26,6 +26,8 @@ import os
 # The path can be overridden via the BRAKER4_CONFIG environment variable so
 # multiple test scenarios can share a single config.ini.
 config_ini_path = os.environ.get('BRAKER4_CONFIG', 'config.ini')
+# Allow trailing # / ; comments on value lines (ConfigParser default is None).
+config_parser = configparser.ConfigParser(inline_comment_prefixes=('#', ';'))
 config_parser = configparser.ConfigParser()
 if not os.path.isfile(config_ini_path):
     raise FileNotFoundError(


### PR DESCRIPTION
Enable support for trailing comments in config parser. 

If Snakemake is executed directly in the current script, an error will occur: 

ValueError in file /array2/xinpeng/fungi_heather/06_annotation/braker4/Snakefile, line 92:
Not a boolean: 1                          # set to 1 for fungal genomes
  File "/array2/xinpeng/fungi_heather/06_annotation/braker4/Snakefile", line 92, in <module>
  File "/home/xinpeng/anaconda3/envs/fungi_anno/lib/python3.11/configparser.py", line 844, in getboolean
  File "/home/xinpeng/anaconda3/envs/fungi_anno/lib/python3.11/configparser.py", line 824, in _get_conv
  File "/home/xinpeng/anaconda3/envs/fungi_anno/lib/python3.11/configparser.py", line 819, in _get
  File "/home/xinpeng/anaconda3/envs/fungi_anno/lib/python3.11/configparser.py", line 1184, in _convert_to_boolean