### PR TITLE
simple fix

### DIFF
--- a/rules/genemark/run_genemark_etp_isoseq.smk
+++ b/rules/genemark/run_genemark_etp_isoseq.smk
@@ -139,6 +139,7 @@ YAMLEOF
         # run_genemark_etp.smk for the full explanation. Also note that
         # get_etp_hints.py uses >> (append) for output, so the file
         # must be truncated first to make the rule re-runnable.
+        ln -s $OUTDIR_ABS/proteins_isoseq.fa $OUTDIR_ABS/proteins.fa
         rm -f {output.etp_hints}
         if get_etp_hints.py \
             --genemark_scripts /opt/ETP/bin \


### PR DESCRIPTION
I can't modify get_etp_hints.py in braker3:isoseq. The script --etp_wdir identifies the writing of subdirectories, and simply uses ln to meet the directory requirements.