### PR TITLE
load omamer_db config

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -148,6 +148,10 @@ config['run_omark'] = config_parser.getboolean(
     'PARAMS', 'run_omark', fallback=False
 )
 
+config['omamer_db'] = config_parser.get(
+    'OMARK', 'omamer_db', fallback=False
+)
+
 config['no_cleanup'] = config_parser.getboolean(
     'PARAMS', 'no_cleanup', fallback=False
 )


### PR DESCRIPTION
  ## Summary
  Load `OMARK.omamer_db` into the Snakefile config map during startup.

  ## Why
  The OMARK configuration section exposes `omamer_db`, but the Snakefile was not reading it into `config`, which left that input unavailable to downstream logic.

  ## Impact
  Users can now provide `omamer_db` through the `OMARK` section and have it available in the workflow configuration.

  ## Validation
  No additional checks were run for this small config-loading change.