### PR TITLE
simple fix

### DIFF
--- a/rules/genemark/run_genemark_etp_isoseq.smk
+++ b/rules/genemark/run_genemark_etp_isoseq.smk
@@ -143,6 +143,7 @@ YAMLEOF
         # valid GeneMark-ETP run. Our isoseq variant writes proteins_isoseq.fa,
         # so symlink the expected name. -f makes the rule re-runnable.
         ln -sf $OUTDIR_ABS/proteins_isoseq.fa $OUTDIR_ABS/proteins.fa
+        ln -s $OUTDIR_ABS/rnaseq/hints/proteins_isoseq.fa $OUTDIR_ABS/rnaseq/hints/proteins.fa
         rm -f {output.etp_hints}
         if get_etp_hints.py \
             --genemark_scripts /opt/ETP/bin \


### PR DESCRIPTION
In the log of genemark_etp_isoseq.log, the file cannot be found, so use ln for simple repair.

BUG：
cat: /home/liwei/Software/BRAKER4/test_scenarios_local/scenario_07_dual/output/bam_isoseq_proteins_masked/GeneMark-ETP-isoseq/rnaseq/hints/proteins.fa/prothint/prothint_augustus.gff: No such file or directory