### PR TITLE
Add missing ncRNA container parameters to support offline execution (run_ncrna=1)

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -112,6 +112,9 @@ _container_defaults = {
     'omark_image':     'docker://quay.io/biocontainers/omark:0.4.1--pyh7e72e81_0',
     'tetools_image':   'docker://dfam/tetools:latest',
     'varus_image':     'docker://katharinahoff/varus-notebook:v0.0.6',
+    'trnascan_image':  'docker://quay.io/biocontainers/trnascan-se:2.0.12--pl5321h031d066_0',
+    'infernal_image':  'docker://quay.io/biocontainers/infernal:1.1.5--pl5321h031d066_2',
+    'feelnc_image':    'docker://quay.io/biocontainers/feelnc:0.2--pl526_0',
 }
 for _img_key, _img_default in _container_defaults.items():
     config[_img_key] = config_parser.get('containers', _img_key, fallback=_img_default)

--- a/config.ini.example
+++ b/config.ini.example
@@ -39,6 +39,9 @@ busco_image = docker://ezlabgva/busco:v6.0.0_cv1
 omark_image = docker://quay.io/biocontainers/omark:0.4.1--pyh7e72e81_0
 tetools_image = docker://dfam/tetools:latest
 varus_image = docker://katharinahoff/varus-notebook:v0.0.6
+trnascan_image=docker://quay.io/biocontainers/trnascan-se:2.0.12--pl5321h031d066_0
+infernal_image=docker://quay.io/biocontainers/infernal:1.1.5--pl5321h031d066_2
+feelnc_image=docker://quay.io/biocontainers/feelnc:0.2--pl526_0
 
 [PARAMS]
 ; Set to 1 for fungal genomes (GeneMark uses branch point model).


### PR DESCRIPTION
### Description / Motivation
When running the pipeline on offline HPC nodes with `run_ncrna=1`, the execution crashes with `connection refused`. 

Although `config.ini` is provided, custom paths for `trnascan_image`, `infernal_image`, and `feelnc_image` are ignored because these keys are missing from the `_container_defaults` dictionary in the main `Snakefile`. Consequently, the pipeline falls back to pulling default `docker://` URIs, which fails without internet access.

### Changes Made
* **`Snakefile`**: Added `trnascan_image`, `infernal_image`, and `feelnc_image` to `_container_defaults`[cite: 3].
* **`config.ini`**: Added these three parameters to the `[containers]` section as a reference.

### Impact
Allows users to specify local `.sif` paths for all ncRNA tools, enabling fully offline execution of the `run_ncrna=1` module.