### PR TITLE
Route samtools sort temp files to the configured tmpdir

### DIFF
--- a/rules/genemark/check_bam_sorted.smk
+++ b/rules/genemark/check_bam_sorted.smk
@@ -75,6 +75,7 @@ rule check_bam_sorted:
             # Sort with parallel threads (fixes BRAKER issue: was -@ 0)
             samtools sort \
                 -@ {threads} \
+                -T {resources.tmpdir}/{wildcards.sample}_{wildcards.bam_id} \
                 -o {output.bam} \
                 {input.bam} \
                 2>> {log}

--- a/rules/postprocessing/add_utr.smk
+++ b/rules/postprocessing/add_utr.smk
@@ -59,7 +59,7 @@ rule run_stringtie:
         if [ $(echo {input.bams} | wc -w) -gt 1 ]; then
             echo "Merging $(echo {input.bams} | wc -w) BAM files..." > {log}
             samtools merge -@ {threads} output/{wildcards.sample}/stringtie/merged.bam {input.bams} 2>> {log}
-            samtools sort -@ {threads} -o output/{wildcards.sample}/stringtie/merged.s.bam output/{wildcards.sample}/stringtie/merged.bam 2>> {log}
+            samtools sort -@ {threads} -T {resources.tmpdir}/{wildcards.sample}_addutr -o output/{wildcards.sample}/stringtie/merged.s.bam output/{wildcards.sample}/stringtie/merged.bam 2>> {log}
             samtools index -@ {threads} output/{wildcards.sample}/stringtie/merged.s.bam 2>> {log}
             INPUT_BAM=output/{wildcards.sample}/stringtie/merged.s.bam
             rm -f output/{wildcards.sample}/stringtie/merged.bam

--- a/rules/preprocessing/check_isoseq_bam.smk
+++ b/rules/preprocessing/check_isoseq_bam.smk
@@ -42,7 +42,7 @@ rule check_isoseq_bam:
         BAM_ABS=$(readlink -f {input.bam})
 
         echo "Sorting IsoSeq BAM file {wildcards.isoseq_id}..." > {log}
-        samtools sort -@ {threads} -o {output.bam} "$BAM_ABS" 2>> {log}
+        samtools sort -@ {threads} -T {resources.tmpdir}/{wildcards.sample}_{wildcards.isoseq_id} -o {output.bam} "$BAM_ABS" 2>> {log}
         echo "Sorting complete" >> {log}
 
         samtools index -@ {threads} {output.bam} 2>> {log}

--- a/rules/preprocessing/hisat2_align.smk
+++ b/rules/preprocessing/hisat2_align.smk
@@ -119,14 +119,14 @@ rule hisat2_align:
                     -2 {params.sra_dir}/{wildcards.align_id}_2.fastq \
                     --dta -p {params.hisat2_threads} \
                     2>> {log} | \
-                    samtools sort -@ {params.sort_threads} -o {output.bam}
+                    samtools sort -@ {params.sort_threads} -T {resources.tmpdir}/{wildcards.sample}_{wildcards.align_id} -o {output.bam}
             elif [ -f "{params.sra_dir}/{wildcards.align_id}.fastq" ]; then
                 echo "Single-end SRA alignment" >> {log}
                 hisat2 -x {params.index_prefix} \
                     -U {params.sra_dir}/{wildcards.align_id}.fastq \
                     --dta -p {params.hisat2_threads} \
                     2>> {log} | \
-                    samtools sort -@ {params.sort_threads} -o {output.bam}
+                    samtools sort -@ {params.sort_threads} -T {resources.tmpdir}/{wildcards.sample}_{wildcards.align_id} -o {output.bam}
             else
                 echo "ERROR: No FASTQ files found for SRA ID {wildcards.align_id}" >> {log}
                 ls -la {params.sra_dir}/ >> {log} 2>&1 || true
@@ -140,7 +140,7 @@ rule hisat2_align:
                 -2 {params.r2} \
                 --dta -p {params.hisat2_threads} \
                 2>> {log} | \
-                samtools sort -@ {params.sort_threads} -o {output.bam}
+                samtools sort -@ {params.sort_threads} -T {resources.tmpdir}/{wildcards.sample}_{wildcards.align_id} -o {output.bam}
         fi
 
         # Index the BAM

--- a/rules/preprocessing/minimap2_isoseq_align.smk
+++ b/rules/preprocessing/minimap2_isoseq_align.smk
@@ -112,7 +112,7 @@ rule sort_isoseq_sam:
         echo "Converting SAM to sorted BAM..." > {log}
 
         samtools view -bS --threads 1 {input.sam} | \
-            samtools sort -@ {params.sort_threads} -o {output.bam} 2>> {log}
+            samtools sort -@ {params.sort_threads} -T {resources.tmpdir}/{wildcards.sample}_{wildcards.isoseq_fastq_id} -o {output.bam} 2>> {log}
 
         samtools index -@ {threads} {output.bam} 2>> {log}
 


### PR DESCRIPTION
## Background

`samtools sort` writes its intermediate spill files to a prefix derived from the output path by default, ignoring `$TMPDIR`.  This PR makes every `samtools sort` invocation spill to Snakemake's `resources.tmpdir` instead, via the `-T` prefix flag.

`resources.tmpdir` is the resource populated by the `default-resources: tmpdir:` key already documented in `profiles/slurm/config.yaml`. When a user sets `tmpdir` there, samtools temp files now honor it — matching the behavior of the GNU `sort` passes the config comment already mentions. When `tmpdir` is left unset, `resources.tmpdir` falls back to the system temp dir, so existing setups are unaffected.

## Changes

Added `-T {resources.tmpdir}/<prefix>` to each `samtools sort` call. No other samtools subcommands were touched — `index`, `view`, `faidx`, `merge`, and `--version` don't write their own temp files.

| File | Rule | Temp prefix |
|------|------|-------------|
| `rules/preprocessing/hisat2_align.smk` (3 calls) | hisat2 alignment | `{sample}_{align_id}` |
| `rules/preprocessing/check_isoseq_bam.smk` | sort IsoSeq BAM | `{sample}_{isoseq_id}` |
| `rules/genemark/check_bam_sorted.smk` | re-sort unsorted BAM | `{sample}_{bam_id}` |
| `rules/postprocessing/add_utr.smk` | merge/sort for StringTie | `{sample}_addutr` |
| `rules/preprocessing/minimap2_isoseq_align.smk` | minimap2 SAM→BAM sort | `{sample}_{isoseq_fastq_id}` |

Each prefix embeds the rule's wildcards so that concurrently running jobs sharing one `tmpdir` cannot collide on temp filenames.
