### PR TITLE
Fix merge_hints failing in ETP mode when join_mult_hints.pl exits non-zero on success

### DIFF
--- a/rules/postprocessing/merge_hints.smk
+++ b/rules/postprocessing/merge_hints.smk
@@ -120,7 +120,14 @@ rule merge_hints:
         # Sort key order matches braker.pl sub join_mult_hints
         # (scripts/braker.pl line 4820): coordinate-based, then stable-sorted
         # by type, then by chromosome.
+        # join_mult_hints.pl can exit non-zero even when it succeeds and
+        # writes valid output (same flaky behavior documented in
+        # run_genemark_etp.smk and README.md for prothint.py/get_etp_hints.py).
+        # Snakemake 8's SLURM executor re-enables -e/pipefail, so disable both
+        # around the pipe and validate the output ourselves afterwards.
         TMP_JOINED={output.hintsfile}.joined
+        set +e
+        set +o pipefail
         cat "$TMP_MERGE" \
             | sort -n -k 4,4 \
             | sort -s -n -k 5,5 \
@@ -128,6 +135,13 @@ rule merge_hints:
             | sort -s -k 1,1 \
             | join_mult_hints.pl \
             > "$TMP_JOINED"
+        JOIN_EXIT=$?
+        set -e
+        set -o pipefail
+        if [ -s "$TMP_MERGE" ] && [ ! -s "$TMP_JOINED" ]; then
+            echo "[ERROR] join_mult_hints.pl produced no output (exit=$JOIN_EXIT) from $N_MERGE_IN merge candidates" | tee -a {output.hints_stats}
+            exit 1
+        fi
         N_JOINED_OUT=$(wc -l < "$TMP_JOINED")
         echo "[INFO] join_mult_hints.pl: $N_MERGE_IN -> $N_JOINED_OUT collapsed hints" | tee -a {output.hints_stats}
 


### PR DESCRIPTION
## Problem

In ETP (short-read) mode, the pipeline dies at the `merge_hints` rule immediately after GeneMark-ETP completes successfully. The rule runs under `set -euo pipefail` and pipes the merged hint stream into `join_mult_hints.pl`:

```bash
cat "$TMP_MERGE" | sort ... | join_mult_hints.pl > "$TMP_JOINED"
```

`join_mult_hints.pl` can return a non-zero exit code even when it succeeds and writes valid output. This is the same flaky behavior already documented and worked around elsewhere in the codebase — see the comment in `rules/genemark/run_genemark_etp.smk` ("gmetp.pl, get_etp_hints.py, and join_mult_hints.pl may return non-zero on success ... Must disable both -e and pipefail; Snakemake 8's SLURM executor re-enables them") and `README.md` §1343 for `prothint.py`/`get_etp_hints.py`. `run_prothint`, `run_prothint_iter2`, and `run_genemark_etp` all guard these calls with `set +e` / `set +o pipefail`; `merge_hints` was the one ETP-path rule that did not, so the spurious exit code combined with `pipefail` killed the run.

## Change

In `rules/postprocessing/merge_hints.smk`, wrap the `join_mult_hints.pl` pipeline in `set +e` / `set +o pipefail`, capture the exit code, then restore strict mode. Add an explicit output check so a *genuine* failure still stops the run loudly instead of silently writing an empty hintsfile:

```bash
if [ -s "$TMP_MERGE" ] && [ ! -s "$TMP_JOINED" ]; then
    echo "[ERROR] join_mult_hints.pl produced no output (exit=$JOIN_EXIT) from $N_MERGE_IN merge candidates" | tee -a {output.hints_stats}
    exit 1
fi
```

This mirrors the existing convention in `run_genemark_etp.smk`: tolerate the false-positive exit code, but validate the output rather than trusting it blindly.

## Behavior

- **Success case** (script exits non-zero but wrote valid hints): the rule now continues instead of failing — the actual fix.
- **Real failure case** (no output produced): the rule fails with a clear, specific error instead of a cryptic `pipefail` death.

No change to the hint contents, sort order, or the `src=C grp=` passthrough logic.

## Testing / notes

Reported on a nematode genome in short-read (ETP) mode: GeneMark-ETP finished cleanly (`training.gtf`, `hc.gff`, and `etp_hints.gff` with ~1.96M hints all present) but the run stopped at `merge_hints`. The original SLURM log was lost, so a green end-to-end rerun with the patch has not yet been confirmed — flagging so a maintainer can verify against an ETP test case before merge.

After fix, the run completed successfully with the same parameters. 


NOTE: Claude Opus 4.8 was used to identify the issue and fix it. 
