### PR TITLE
Remove conda environment specification

### DIFF
--- a/rules/postprocessing/run_fantasia.smk
+++ b/rules/postprocessing/run_fantasia.smk
@@ -50,8 +50,6 @@ rule fantasia_annotate:
         lookup_dir=FANTASIA_LOOKUP_DIR,
         add_params=FANTASIA_ADD_PARAMS,
         outdir=lambda wc: f"output/{wc.sample}/fantasia"
-    conda:
-        envs/singularity.yaml
     threads:
         int(config['fantasia'].get('cpus_per_task', config['slurm_args']['cpus_per_task']))
     resources:


### PR DESCRIPTION
This is probably under active development, but just in case this has not come up yet:

This conda environment specification probably got here by accident, as no other rule uses a conda environment and the specified yaml file does not exist. The `run_fantasia.smk` also mentions a `/scripts/generate_embeddings.py` script that does not seem to be committed anywhere.